### PR TITLE
Semester Model and Control refactor

### DIFF
--- a/App/models/semester.py
+++ b/App/models/semester.py
@@ -1,33 +1,42 @@
 from App.database import db
+from datetime import datetime, date
 
 class Semester(db.Model):
-    __tablename__ = 'semester'
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    start_date = db.Column(db.Date, nullable=False)
-    end_date = db.Column(db.Date, nullable=False)
-    sem_num = db.Column(db.Integer, nullable=False)
-    max_assessments = db.Column(db.Integer, nullable=False)
-    K = db.Column(db.Integer, nullable=False)  # Total days in a semester
-    d = db.Column(db.Integer, nullable=False)  # Number of days between assessments for overlapping courses
-    M = db.Column(db.Integer, nullable=False)  # Constraint constant
+    id: int = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    start_date: date = db.Column(db.Date, nullable=False)
+    end_date: date = db.Column(db.Date, nullable=False)
+    sem_num:int = db.Column(db.Integer, nullable=False, default = 1)
+    max_assessments: int = db.Column(db.Integer, nullable=False)
+    constraint_value:int = db.Column(db.Integer, nullable = False, default = 1000)
+    active: bool = db.Column(db.Boolean, nullable = False, default = False)
 
-    def __init__(self, start_date, end_date, sem_num, max_assessments, K=84, d=3, M=1000):
+    def __init__(self, start_date, end_date, sem_num, max_assessments, constraint_value = 1000, active = False, course_overlap_window = 0):
         self.start_date = start_date
         self.end_date = end_date
         self.sem_num = sem_num
         self.max_assessments = max_assessments
-        self.K = K
-        self.d = d
-        self.M = M
+        self.constraint_value = constraint_value
+        self.active = active
+        self.course_overlap_window = course_overlap_window
 
     def to_json(self):
         return {
-            "id": self.id,
-            "start_date": self.start_date,
-            "end_date": self.end_date,
-            "sem_num": self.sem_num,
-            "max_assessments": self.max_assessments,
-            "K": self.K,
-            "d": self.d,
-            "M": self.M
+            'id': self.id,
+            'start_date': self.start_date.isoformat(),
+            'end_date': self.end_date.isoformat(),
+            'sem_num': self.sem_num,
+            'max_assessments': self.max_assessments,
+            'constraint value': self.constraint_value,
+            'active' : self.active,
         }
+
+    def __repr__(self):
+        return (f"ID: {self.id}, "
+                f"Start Date: {self.start_date}, "
+                f"End Date: {self.end_date}, "
+                f"Semester Number: {self.sem_num}, "
+                f"Max Assessments: {self.max_assessments}, "
+                f"Active: {self.active}")
+    
+# Active is set to False to default and controller logic is uesd to ensure only one semester can be active at a time
+# Semesters store dates as date objects, but conversion from Strings to Dates happens using the create_semester method in the controller.


### PR DESCRIPTION
The Semester model should contain configurable variables (such as the minimum amount of days between assessments) that can be fed into kris.py, the refactored semester model provides variables such as `start-date`,`end-date`,`constraint_value`,`max-assessments` and `active`. The controller allows these variables to be used by `kris.py`. Controller logic now makes it such that only one semester can be active at a time because of the `active` boolean. And the duration of a semester can be computed by `db.Date` subtraction