### PR TITLE
Stabilize Calendar Route

### DIFF
--- a/App/models/assessment.py
+++ b/App/models/assessment.py
@@ -24,6 +24,8 @@ class Assessment(db.Model):
     
     def to_json(self):
         return {
+            'id': self.id,
+            'course_code': self.course_code,
             'name': self.name,
             'percentage': self.percentage,
             'start_week': self.start_week,
@@ -31,9 +33,8 @@ class Assessment(db.Model):
             'end_week': self.end_week,
             'end_day': self.end_day,
             'proctored': self.proctored,
-            'scheduled' : self.scheduled
+            'scheduled': self.scheduled
         }
     
     def __repr__(self):
         return f'{self.course_code} {self.name}: {self.percentage}% Scheduled for { "N/A" if self.scheduled is None else self.scheduled}'
-    

--- a/App/templates/calendar.html
+++ b/App/templates/calendar.html
@@ -6,36 +6,97 @@
 <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js'></script>
 <link rel="stylesheet" href="../static/css/style.css">
 <style>
-  .unscheduled-assessments {
-    padding: 20px;
-    background: var(--primary-color);
-    border-radius: 8px;
-    margin-bottom: 20px;
+  /* Enhanced styles for the unscheduled assessments panel */
+  #unscheduled-list {
+    padding: 10px;
+    background: var(--secondary-color);
+    border-radius: 5px;
+    margin-top: 20px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    max-height: 500px;
+    overflow-y: auto;
   }
   
-  .unscheduled-assessments h3 {
-    color: white;
-    margin-bottom: 15px;
+  #unscheduled-list h3 {
+    margin-top: 0;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #444;
+    color: #fff;
   }
   
   .draggable-assessment {
-    background: var(--secondary-color);
+    background: var(--tertiary-color);
     padding: 10px;
-    margin: 5px 0;
+    margin-bottom: 10px;
     border-radius: 4px;
     cursor: move;
-    color: white;
-    border-left: 4px solid var(--tertiary-color);
+    border-left: 4px solid #fff;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    transition: all 0.2s ease;
+    color: #fff;
+  }
+  
+  .draggable-assessment:hover {
+    box-shadow: 0 3px 6px rgba(0,0,0,0.3);
+    transform: translateY(-2px);
+    background: #503b9a;
   }
   
   .draggable-assessment.proctored {
-    border-left-color: #CC4E4E;
+    border-left: 4px solid #9C9FE2;
   }
   
-  .assessment-info {
-    font-size: 0.9em;
-    color: #ccc;
+  .assessment-details {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.8);
     margin-top: 5px;
+  }
+  
+  .assessment-name {
+    font-weight: bold;
+    display: block;
+    margin-bottom: 5px;
+    color: #fff;
+  }
+  
+  .badge {
+    background: var(--tertiary-color);
+    color: #fff;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+    margin-left: 5px;
+  }
+  
+  /* Layout adjustments */
+  #main {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  
+  #calendar {
+    flex: 1;
+    min-width: 600px;
+    margin-right: 20px;
+  }
+  
+  #nav {
+    width: 250px;
+  }
+  
+  @media (max-width: 992px) {
+    #main {
+      flex-direction: column;
+    }
+    
+    #calendar {
+      margin-right: 0;
+      margin-bottom: 20px;
+    }
+    
+    #nav {
+      width: 100%;
+    }
   }
 </style>
 {% endblock %}
@@ -53,68 +114,67 @@
     <select id="courses">
       <option value="My Courses">My Courses</option>
       <option value="all">ALL</option>
-      {% for course in staff_courses %}
-      <option value="{{course.code}}">{{course.code}} - {{course.name}}</option>
+      {% for course in courses %}
+      <option value="{{course.code}}">{{course.code}}</option>
       {% endfor %}
     </select>
-
+    
     <select id="assignmentType">
       <option value="all">All Types</option>
-      <option value="0">Assignments</option>
-      <option value="1">Proctored Exams</option>
+      <option value="0">Regular</option>
+      <option value="1">Proctored</option>
     </select>
   </div>
+  
   <div id="main">
     <div id="calendar"></div>
     <div id="nav">
-      <div class="unscheduled-assessments">
+      <div id="unscheduled-list">
         <h3>Unscheduled Assessments</h3>
-        <div id="unscheduled-list">
+        {% if unscheduled_assessments %}
           {% for assessment in unscheduled_assessments %}
-          <div class="draggable-assessment {% if assessment.proctored %}proctored{% endif %}"
-               data-assessment-id="{{ assessment.id }}"
-               data-course-code="{{ assessment.course_code }}"
-               data-percentage="{{ assessment.percentage }}"
-               data-proctored="{{ assessment.proctored }}">
-            <div>{{ assessment.course_code }} - {{ assessment.name }}</div>
-            <div class="assessment-info">
-              Percentage: {{ assessment.percentage }}%
-              {% if assessment.proctored %}
-              | Proctored
-              {% endif %}
+            <div class="draggable-assessment {% if assessment.proctored %}proctored{% endif %}" 
+                data-assessment-id="{{ assessment.id }}" 
+                data-course-code="{{ assessment.course_code }}" 
+                data-percentage="{{ assessment.percentage }}"
+                data-proctored="{{ assessment.proctored }}">
+              <span class="assessment-name">{{ assessment.name }}</span>
+              <div class="assessment-details">
+                {{ assessment.course_code }} | Weight: {{ assessment.percentage }}%
+                {% if assessment.proctored %}<span class="badge">Proctored</span>{% endif %}
+              </div>
             </div>
-          </div>
           {% endfor %}
-        </div>
+        {% else %}
+          <p>No unscheduled assessments found.</p>
+        {% endif %}
       </div>
     </div>
   </div>
 </div>
-
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.6.0/gsap.min.js"></script>
 <script>
-  // Pass model data to JavaScript with proper defaults
-  var scheduledAssessments = {{ scheduled_assessments | tojson }} || [];
-  var unscheduledAssessments = {{ unscheduled_assessments | tojson }} || [];
-  var myCourses = {{ staff_courses | tojson }} || [];
-  var semester = {{ semester | tojson }} || { start_date: null, end_date: null };
+  // Essential variables for calendar functionality
+  var staff_exams = {{ staff_exams | tojson }};
+  var myCourses = {{ staff_courses | tojson }};
+  var semester = {{ semester | tojson }};
+  var otherExams = {{ other_exams | tojson }};
   
-  // Add semester week data for calculations
-  var semesterStartDate = semester.start_date ? new Date(semester.start_date) : new Date();
-  var semesterEndDate = semester.end_date ? new Date(semester.end_date) : new Date();
-  var semesterWeeks = Math.ceil((semesterEndDate - semesterStartDate) / (7 * 24 * 60 * 60 * 1000)) || 15;
+  // Variables specifically needed by index.js
+  var scheduledAssessments = {{ scheduled_assessments | tojson }};
+  var unscheduledAssessments = {{ unscheduled_assessments | tojson }};
   
-  // Function to convert week/day to actual dates
-  function getDateFromWeekDay(startDate, week, day) {
-    if (!(startDate instanceof Date) || isNaN(startDate)) {
-      startDate = new Date();
-    }
-    const result = new Date(startDate);
-    result.setDate(result.getDate() + (week - 1) * 7 + day - 1);
-    return result;
+  // Calculate semester duration in weeks
+  var semesterWeeks = 15;  // Default if semester dates not available
+  if (semester && semester.start_date && semester.end_date) {
+    const startDate = new Date(semester.start_date);
+    const endDate = new Date(semester.end_date);
+    const daysDiff = Math.ceil((endDate - startDate) / (1000 * 60 * 60 * 24));
+    semesterWeeks = Math.ceil(daysDiff / 7);
   }
 </script>
 <script src="{{url_for('static', filename='index.js')}}"></script>
 <script src="{{url_for('static', filename='js/mobileMenu.js')}}"></script>
+
 {% endblock %}

--- a/App/views/staff.py
+++ b/App/views/staff.py
@@ -17,6 +17,30 @@ from ..controllers import (
 
 staff_views = Blueprint('staff_views', __name__, template_folder='../templates')
 
+@staff_views.route('/signup', methods=['GET'])
+def get_signup_page():
+    return render_template('signup.html')
+
+@staff_views.route('/register', methods=['POST'])
+def register_staff_action():
+    try:
+        first_name = request.form.get('first_name')
+        last_name = request.form.get('last_name')
+        id = request.form.get('id')
+        email = request.form.get('email')
+        password = request.form.get('password')
+        
+        staff = create_staff(id, email, password, first_name, last_name)
+        if staff:
+            flash('Registration successful! Please log in.', 'success')
+            return redirect(url_for('auth_views.get_login_page'))
+        else:
+            flash('Registration failed. Email may already be in use.', 'error')
+            return redirect(url_for('staff_views.get_signup_page'))
+    except Exception as e:
+        flash(f'An error occurred: {str(e)}', 'error')
+        return redirect(url_for('staff_views.get_signup_page'))
+
 @staff_views.route('/account', methods=['GET'])
 @jwt_required(Staff)
 def get_account_page():
@@ -28,6 +52,7 @@ def get_account_page():
         num_assessments  = num_assessments + get_num_assessments(course.code)
     return render_template('account.html', staff=staff, courses=courses, num_assessments = num_assessments)
 
+# Calendar and assessment routes removed - now handled in assessment_views
 
 @staff_views.route('/settings', methods=['GET'])
 @jwt_required()


### PR DESCRIPTION
Made adjustments to ensure /calendar would be usable with staff data.
Further refinements to be made:
- Calendar should initialize all scheduled assessments on itself whenever it is loaded.
- Calendar needs to handle data for drag and drop scheduling appropriately
- Calendar page needs a button to auto-schedule using one of the available solvers.  